### PR TITLE
Add non-core neighbors to the cluster

### DIFF
--- a/src/dbscan.rs
+++ b/src/dbscan.rs
@@ -92,15 +92,14 @@ impl Dbscan {
         for &neighbor in &neighborhoods[core_idx] {
             if visited[neighbor] {
                 continue;
+            } else {
+                let cluster = clusters.entry(cid).or_insert_with(|| vec![]);
+                cluster.push(neighbor);
+                visited[neighbor] = true;
             }
-            visited[neighbor] = true;
             let neighbors = &neighborhoods[neighbor];
             if neighbors.len() < self.min_cluster_size {
                 continue;
-            }
-            {
-                let cluster = clusters.entry(cid).or_insert_with(|| vec![]);
-                cluster.push(neighbor);
             }
             self.expand_cluster(db, input, neighbor, cid, &neighborhoods, visited, clusters);
         }


### PR DESCRIPTION
Previously it skipped non-core neighbors, resulting in a cluster
smaller than `min_cluster_size`.
