### PR TITLE
Allow input for `Fit` and `Predict` to be non-`Sized`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2020-04-13
+
+### Changed
+
+- The input type of `Fit` and `Predict` no longer has to be `Sized`. With this
+  chagne, the caller may pass a slice as an input.
+
 ## [0.2.0] - 2020-04-10
 
 ### Changed
@@ -20,5 +27,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - The [OPTICS](https://en.wikipedia.org/wiki/OPTICS_algorithm) clustering
   algorithm.
 
+[0.2.1]: https://github.com/petabi/petal-clustering/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/petabi/petal-clustering/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/petabi/petal-clustering/tree/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "petal-clustering"
-version = "0.2.0"
+version = "0.2.1"
 description = "A collection of clustering algorithms."
+readme = "README.md"
 homepage = "https://github.com/petabi/petal-clustering"
 repository = "https://github.com/petabi/petal-clustering"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A collection of clustering algorithms. Currently this crate provides DBSCAN and
 OPTICS.
 
+[![crates.io](https://img.shields.io/crates/v/petal-clustering)](https://crates.io/crates/petal-clustering)
+[![Documentation](https://docs.rs/petal-clustering/badge.svg)](https://docs.rs/petal-clustering)
 [![Coverage Status](https://codecov.io/gh/petabi/petal-clustering/branch/master/graphs/badge.svg)](https://codecov.io/gh/petabi/petal-clustering)
 
 ## Requirements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,17 @@ pub use dbscan::Dbscan;
 pub use optics::Optics;
 
 /// An interface to train a model.
-pub trait Fit<I, O> {
+pub trait Fit<I, O>
+where
+    I: ?Sized,
+{
     fn fit(&mut self, input: &I) -> O;
 }
 
 /// An interface to apply a trained model.
-pub trait Predict<I, O> {
+pub trait Predict<I, O>
+where
+    I: ?Sized,
+{
     fn predict(&mut self, input: &I) -> O;
 }


### PR DESCRIPTION
The input type of `Fit` and `Predict` no longer has to be `Sized`. With this chagne, the caller may pass a slice as an input.