### PR TITLE
Use tarpaulin for code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,21 @@ jobs:
       with:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
+    - name: Install Tarpaulin
+      if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+      run: cargo install cargo-tarpaulin
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Generate coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-      run: |
-        sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
-        wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
-        tar xzf master.tar.gz
-        cd kcov-master
-        mkdir build && cd build
-        cmake .. && make
-        make install DESTDIR=../../kcov-build
-        cd ../..
-        rm -rf kcov-master
-        for file in target/debug/petal_clustering-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done
+      run: cargo tarpaulin --out Xml
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       uses: codecov/codecov-action@master
       with:
         token: ${{secrets.CODECOV_TOKEN}}
-    - name: Install components
-      if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-      run: rustup component add clippy rustfmt
     - name: Check formatting
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       run: cargo fmt -- --check


### PR DESCRIPTION
Tarpaulin is a code coverage reporting tool written in Rust. This replaces kcov, which required installing many library packages, often leading to network-related errors.

Note: Because Tarpaulin's coverage calculation is slightly different from kcov, this pull request shows lower coverage even though it contains no change in Rust files.