### PR TITLE
fix dual-tree traversal

### DIFF
--- a/src/hdbscan.rs
+++ b/src/hdbscan.rs
@@ -735,11 +735,11 @@ where
                 let left_bound = self.db.node_distance_lower_bound(reference, left);
                 let right_bound = self.db.node_distance_lower_bound(reference, right);
                 if left_bound < right_bound {
-                    self.traversal(reference, left);
-                    self.traversal(reference, right);
+                    self.traversal(left, reference);
+                    self.traversal(right, reference);
                 } else {
-                    self.traversal(reference, right);
-                    self.traversal(reference, left);
+                    self.traversal(right, reference);
+                    self.traversal(left, reference);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the bug that's causing `HDbscan` with `boruvka: true` to produce a heavier MST than `HDbscan` with `boruvka: false`. 

The order of dual-tree traversal between `query` and `reference` trees seems to be misplaced, please check the Python HDBSCAN code [here](https://github.com/scikit-learn-contrib/hdbscan/blob/98928d0c095715edc9584e7989bd8559673bc2f0/hdbscan/_hdbscan_boruvka.pyx#L1431). 