### PR TITLE
Add cluster extraction

### DIFF
--- a/examples/hdbscan.rs
+++ b/examples/hdbscan.rs
@@ -2,7 +2,7 @@ use std::{env, fs::File, process::exit};
 
 use csv::ReaderBuilder;
 use ndarray::Array2;
-use petal_clustering::{Fit, HDbscan};
+use petal_clustering::{Fit, HDbscan, ClusterExtraction};
 use petal_neighbors::distance::Euclidean;
 
 fn main() {
@@ -39,7 +39,7 @@ fn main() {
         min_cluster_size,
         metric: Euclidean::default(),
         boruvka: true,
-        extraction: petal_clustering::ClusterExtraction::ExcessOfMass,
+        extraction: ClusterExtraction::ExcessOfMass,
     };
     let (clusters, noise, outlier_scores) = clustering.fit(&data.view(), None);
     println!("========= Report =========");

--- a/examples/hdbscan.rs
+++ b/examples/hdbscan.rs
@@ -2,7 +2,7 @@ use std::{env, fs::File, process::exit};
 
 use csv::ReaderBuilder;
 use ndarray::Array2;
-use petal_clustering::{Fit, HDbscan, ClusterExtraction};
+use petal_clustering::{ClusterExtraction, Fit, HDbscan};
 use petal_neighbors::distance::Euclidean;
 
 fn main() {

--- a/examples/hdbscan.rs
+++ b/examples/hdbscan.rs
@@ -39,6 +39,7 @@ fn main() {
         min_cluster_size,
         metric: Euclidean::default(),
         boruvka: true,
+        extraction: petal_clustering::ClusterExtraction::ExcessOfMass,
     };
     let (clusters, noise, outlier_scores) = clustering.fit(&data.view(), None);
     println!("========= Report =========");

--- a/src/hdbscan.rs
+++ b/src/hdbscan.rs
@@ -78,8 +78,9 @@ where
 /// The cluster extraction method used in HDBSCAN.
 /// - `ExcessOfMass`: Unsupervised clustering using Excess of Mass (`EoM`) algorithm.
 /// - `Fbcubed`: Semi-supervised clustering using F-BCubed (`FBC`) algorithm.
-/// - `Mixed`: Semi-supervised clustering using a mixture of `EoM` and `FBC` algorithms.
-/// - `Classification`: Semi-supervised classification using the partially labeled data.
+///
+/// # Notes
+/// - `Fbcubed` switches to `ExcessOfMass` when no partial labels are provided.
 ///
 /// # References
 /// - Campello, Ricardo JGB, et al. "Hierarchical density estimates for data clustering, visualization, and outlier detection."
@@ -90,8 +91,6 @@ where
 pub enum ClusterExtraction {
     ExcessOfMass,
     Fbcubed,
-    Mixed,
-    Classification,
 }
 
 /// Fits the HDBSCAN clustering algorithm to the given input data.
@@ -379,10 +378,6 @@ fn find_clusters<A: FloatCore + FromPrimitive + AddAssign + Sub>(
                     // where ties are broken by stability
                     *node_bcubed > subtree_bcubed
                         || (*node_bcubed == subtree_bcubed && *node_stability >= subtree_stability)
-                }
-                _ => {
-                    // not implemented yet
-                    panic!("Unsupported cluster extraction method: {extraction:?}");
                 }
             };
 

--- a/src/hdbscan.rs
+++ b/src/hdbscan.rs
@@ -683,7 +683,7 @@ mod test {
 
         // Empty partial labels (should return the same result as unsupervised clustering)
         let partial_labels: HashMap<usize, Vec<usize>> = HashMap::new();
-        let (answer, noise, _) = hdbscan.fit(&data, Some(&partial_labels));
+        let (answer, noise, _) = hdbscan.fit_with_labels(&data, &partial_labels);
         assert_eq!(answer, clusters);
         assert_eq!(noise, [15]);
 
@@ -693,7 +693,7 @@ mod test {
         partial_labels.insert(1, vec![3, 4]);
         partial_labels.insert(2, vec![6]);
         partial_labels.insert(3, vec![11]);
-        let (clusters, noise, _) = hdbscan.fit(&data, Some(&partial_labels));
+        let (clusters, noise, _) = hdbscan.fit_with_labels(&data, &partial_labels);
         assert_eq!(clusters.len(), 3); // 3 clusters found
         assert_eq!(noise, [15]); // 1 outlier found
         let c1 = clusters.keys().find(|k| clusters[k].contains(&0)).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod optics;
 mod union_find;
 
 pub use dbscan::Dbscan;
-pub use hdbscan::HDbscan;
+pub use hdbscan::{ClusterExtraction, HDbscan};
 pub use optics::Optics;
 
 /// An interface to train a model.
@@ -21,6 +21,10 @@ where
     I: ?Sized,
 {
     fn fit(&mut self, input: &I, params: Option<&P>) -> O;
+
+    fn fit_with_labels(&mut self, input: &I, partial_labels: &P) -> O {
+        self.fit(input, Some(partial_labels))
+    }
 }
 
 /// An interface to apply a trained model.


### PR DESCRIPTION
This PR adds `ClusterExtraction` parameter to `Hdbscan`: this enables users set the cluster extraction method explicitly when configuring `Hdbscan`:
```
let mut hdbscan = HDbscan {
   alpha: 1.,
   min_samples: 2,
   min_cluster_size: 2,
   metric: Euclidean::default(),
   boruvka: false,
   extraction: ClusterExtraction::ExcessOfMass, // or Fbcubed
};
```